### PR TITLE
fix(core): improve aria-label for column menu button accessibility #7152

### DIFF
--- a/packages/core/src/js/en.js
+++ b/packages/core/src/js/en.js
@@ -9,7 +9,7 @@
           aria: {
             defaultFilterLabel: 'Filter for column',
             removeFilter: 'Remove Filter',
-            columnMenuButtonLabel: 'Column Menu',
+            columnMenuButtonLabel: 'Column Menu Button',
             column: 'Column'
           },
           priority: 'Priority:',


### PR DESCRIPTION
Fixes #7152 - Changed columnMenuButtonLabel from 'Column Menu' to 'Column Menu Button' to prevent screen readers from repeating the word 'menu'
