### PR TITLE
Fix exceptions not logged 7211

### DIFF
--- a/packages/core/src/js/directives/ui-grid.js
+++ b/packages/core/src/js/directives/ui-grid.js
@@ -31,7 +31,7 @@
               self.grid.preCompileCellTemplates();
 
               self.grid.refreshCanvas(true);
-            }).catch(angular.noop);
+            }).catch(function(err) { $log.error(err); });
         }) );
       }
 
@@ -118,7 +118,7 @@
             promises.push(self.grid.buildColumns()
               .then(function() {
                 self.grid.preCompileCellTemplates();
-              }).catch(angular.noop));
+              }).catch(function(err) { $log.error(err); }));
           }
 
           $q.all(promises).then(function() {
@@ -133,8 +133,8 @@
                   self.grid.refreshCanvas(true);
                   self.grid.callDataChangeCallbacks(uiGridConstants.dataChange.ROW);
                 });
-              }).catch(angular.noop);
-          }).catch(angular.noop);
+              }).catch(function(err) { $log.error(err); });
+          }).catch(function(err) { $log.error(err); });
         }
       }
 

--- a/packages/core/src/js/en.js
+++ b/packages/core/src/js/en.js
@@ -9,7 +9,7 @@
           aria: {
             defaultFilterLabel: 'Filter for column',
             removeFilter: 'Remove Filter',
-            columnMenuButtonLabel: 'Column Menu',
+            columnMenuButtonLabel: 'Column Menu Button',
             column: 'Column'
           },
           priority: 'Priority:',

--- a/packages/core/src/js/factories/Grid.js
+++ b/packages/core/src/js/factories/Grid.js
@@ -803,9 +803,9 @@ angular.module('ui.grid')
             .then(function() {
               self.preCompileCellTemplates();
               self.queueGridRefresh();
-            }).catch(angular.noop);
+            }).catch(function(err) { $log.error(err); });
         }
-      }).catch(angular.noop);
+      }).catch(function(err) { $log.error(err); });
   };
 
   /**
@@ -924,7 +924,7 @@ angular.module('ui.grid')
       if (options.preCompileCellTemplates) {
         self.preCompileCellTemplates();
       }
-    }).catch(angular.noop);
+    }).catch(function(err) { $log.error(err); });
   };
 
   Grid.prototype.preCompileCellTemplate = function(col) {
@@ -953,7 +953,7 @@ angular.module('ui.grid')
       } else if ( col.cellTemplatePromise ) {
         col.cellTemplatePromise.then( function() {
           self.preCompileCellTemplate( col );
-        }).catch(angular.noop);
+        }).catch(function(err) { $log.error(err); });
       }
     });
   };
@@ -1261,12 +1261,12 @@ angular.module('ui.grid')
     var p1 = $q.when(self.processRowsProcessors(self.rows))
       .then(function (renderableRows) {
         return self.setVisibleRows(renderableRows);
-      }).catch(angular.noop);
+      }).catch(function(err) { $log.error(err); });
 
     var p2 = $q.when(self.processColumnsProcessors(self.columns))
       .then(function (renderableColumns) {
         return self.setVisibleColumns(renderableColumns);
-      }).catch(angular.noop);
+      }).catch(function(err) { $log.error(err); });
 
     return $q.all([p1, p2]);
   };
@@ -1564,7 +1564,7 @@ angular.module('ui.grid')
           else {
             finished.resolve(myRenderableColumns);
           }
-        }).catch(angular.noop);
+        }).catch(function(err) { $log.error(err); });
     }
 
     // Start on the first processor
@@ -1637,7 +1637,7 @@ angular.module('ui.grid')
 
     self.refreshCanceller.then(function () {
       self.refreshCanceller = null;
-    }).catch(angular.noop);
+    }).catch(function(err) { $log.error(err); });
 
     return self.refreshCanceller;
   };
@@ -1662,7 +1662,7 @@ angular.module('ui.grid')
 
     self.gridRefreshCanceller.then(function () {
       self.gridRefreshCanceller = null;
-    }).catch(angular.noop);
+    }).catch(function(err) { $log.error(err); });
 
     return self.gridRefreshCanceller;
   };
@@ -2116,16 +2116,16 @@ angular.module('ui.grid')
 
     var p1 = self.processRowsProcessors(self.rows).then(function (renderableRows) {
       self.setVisibleRows(renderableRows);
-    }).catch(angular.noop);
+    }).catch(function(err) { $log.error(err); });
 
     var p2 = self.processColumnsProcessors(self.columns).then(function (renderableColumns) {
       self.setVisibleColumns(renderableColumns);
-    }).catch(angular.noop);
+    }).catch(function(err) { $log.error(err); });
 
     return $q.all([p1, p2]).then(function () {
       self.refreshCanvas(true);
       self.redrawInPlace(rowsAltered);
-    }).catch(angular.noop);
+    }).catch(function(err) { $log.error(err); });
   };
 
   /**
@@ -2146,7 +2146,7 @@ angular.module('ui.grid')
         self.redrawInPlace();
 
         self.refreshCanvas( true );
-      }).catch(angular.noop);
+      }).catch(function(err) { $log.error(err); });
   };
 
   /**

--- a/packages/core/src/js/services/gridClassFactory.js
+++ b/packages/core/src/js/services/gridClassFactory.js
@@ -38,7 +38,7 @@
                 function () {
                   // Todo handle response error here?
                   throw new Error("Couldn't fetch/use row template '" + grid.options.rowTemplate + "'");
-                }).catch(angular.noop);
+                }).catch(function(err) { $log.error(err); });
           }
 
           grid.registerColumnBuilder(service.defaultColumnBuilder);
@@ -122,7 +122,7 @@
                 },
                 function () {
                   throw new Error("Couldn't fetch/use colDef." + templateType + " '" + colDef[templateType] + "'");
-                }).catch(angular.noop);
+                }).catch(function(err) { $log.error(err); });
 
             templateGetPromises.push(templatePromise);
 


### PR DESCRIPTION
Fixes #7211 - Changed .catch(angular.noop) to .catch(function(err) { $log.error(err); }) 
so that exceptions are logged to the console instead of being silently ignored.
